### PR TITLE
Fix: Persistent document context and conversation history for advisors

### DIFF
--- a/src/services/advisorAI.ts
+++ b/src/services/advisorAI.ts
@@ -240,6 +240,7 @@ Respond as the Host, providing facilitation guidance, process suggestions, or be
     options?: {
       temperature?: number;
       maxTokens?: number;
+      conversationHistory?: Array<{ role: 'user' | 'assistant'; content: string }>;
     }
   ): Promise<string> {
     const messages: AIMessage[] = [
@@ -247,13 +248,28 @@ Respond as the Host, providing facilitation guidance, process suggestions, or be
         role: 'system',
         content: customSystemPrompt,
       },
-      {
-        role: 'user',
-        content: userMessage,
-      },
     ];
 
-    console.log('AdvisorAI: About to call generateResponse with custom prompt');
+    // Include conversation history to maintain context across turns
+    if (options?.conversationHistory && options.conversationHistory.length > 0) {
+      console.log(`AdvisorAI: Including ${options.conversationHistory.length} previous conversation turns for context`);
+
+      // Add previous conversation turns (user and assistant exchanges)
+      for (const turn of options.conversationHistory) {
+        messages.push({
+          role: turn.role,
+          content: turn.content,
+        });
+      }
+    }
+
+    // Add current user message
+    messages.push({
+      role: 'user',
+      content: userMessage,
+    });
+
+    console.log(`AdvisorAI: About to call generateResponse with custom prompt (${messages.length} total messages including system prompt and ${options?.conversationHistory?.length || 0} history turns)`);
     const response = await this.client.generateResponse(messages, {
       temperature: options?.temperature || 0.8,
       maxTokens: options?.maxTokens || 1000,


### PR DESCRIPTION
CRITICAL FIXES:
1. Advisors now receive full conversation history (not just current message)
2. Uploaded documents persist across entire conversation
3. Enhanced context continuity for multi-turn document discussions

TECHNICAL CHANGES:

## advisorAI.ts
- Added conversationHistory parameter to generateResponseWithCustomPrompt()
- Messages array now includes previous user/assistant exchanges
- Advisors can reference previous responses and maintain continuity
- Increased context logging for debugging

## AdvisoryConversation.tsx
- Created conversationDocuments state for persistent document storage
- Extract and store document content on upload (not just first message)
- Include last 10 messages (5 exchanges) in conversation history
- Increased relevance scoring context from 5 to 20 messages
- Added comprehensive context instructions in system prompt
- Updated saveConversation/loadConversation to persist document content
- Filter conversation history by advisor for individual threads

IMPACT:
- First turn: Advisors see uploaded documents ✓
- Second turn: Advisors remember documents AND previous discussion ✓
- Third+ turns: Full context maintained throughout conversation ✓
- Page reload: Document content persists via localStorage ✓

Resolves the issue where advisors would "lose track" of uploaded materials after the first conversation round.